### PR TITLE
Validation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ eight_points_guzzle:
 | password | The resource owner password | for PasswordCredentials grant type | A3ddj3w |
 | auth_location | The place where to put client_id and client_secret in auth request. <br/>Default: headers. Allowed values: body, headers. | no | body |
 | resource | The App ID URI of the web API (secured resource) | no | https://service.contoso.com/ |
+| private_key | Path to private key | for JwtBearer grant type | `"%kernel.root_dir%/path/to/private.key"` |
 | scope | One or more scope values indicating which parts of the user's account you wish to access | no | administration |
 | grant_type | Grant type class path. Class should implement GrantTypeInterface. <br/> Default: `Sainsburys\\Guzzle\\Oauth2\\GrantType\\ClientCredentials` | no | `Sainsburys\\Guzzle\\Oauth2\\GrantType\\PasswordCredentials`<br/>`Sainsburys\\Guzzle\\Oauth2\\GrantType\\AuthorizationCode`<br/>`Sainsburys\\Guzzle\\Oauth2\\GrantType\\JwtBearer` |
 

--- a/README.md
+++ b/README.md
@@ -43,29 +43,7 @@ new EightPoints\Bundle\GuzzleBundle\EightPointsGuzzleBundle([
 ```
 
 ### Basic configuration
-#### With password grant type
-``` yaml
-# app/config/config.yml
-
-eight_points_guzzle:
-    clients:
-        api_payment:
-            base_url: "http://api.domain.tld"
-            
-            auth: oauth2
-
-            # plugin settings
-            plugin:
-                oauth2:
-                    base_uri:       "https://example.com"
-                    token_url:      "/oauth/token"
-                    username:       "test@example.com"
-                    password:       "pa55w0rd"
-                    client_id:      "test-client-id"
-                    scope:          "administration"
-```
-
-#### With client credentials grant type
+#### With default grant type (client)
 ``` yaml
 # app/config/config.yml
 
@@ -84,7 +62,29 @@ eight_points_guzzle:
                     client_id:      "test-client-id"
                     client_secret:  "test-client-secret" # optional
                     scope:          "administration"
-                    grant_type:     "Sainsburys\\Guzzle\\Oauth2\\GrantType\\ClientCredentials"
+```
+
+#### With password grant type
+``` yaml
+# app/config/config.yml
+
+eight_points_guzzle:
+    clients:
+        api_payment:
+            base_url: "http://api.domain.tld"
+            
+            auth: oauth2
+
+            # plugin settings
+            plugin:
+                oauth2:
+                    base_uri:       "https://example.com"
+                    token_url:      "/oauth/token"
+                    client_id:      "test-client-id"
+                    username:       "johndoe"
+                    password:       "A3ddj3w"
+                    scope:          "administration"
+                    grant_type:     "Sainsburys\\Guzzle\\Oauth2\\GrantType\\PasswordCredentials"
 ```
 
 #### With client credentials in body
@@ -104,9 +104,7 @@ eight_points_guzzle:
                     base_uri:       "https://example.com"
                     token_url:      "/oauth/token"
                     client_id:      "test-client-id"
-                    client_secret:  "test-client-secret" # optional
                     scope:          "administration"
-                    grant_type:     "Sainsburys\\Guzzle\\Oauth2\\GrantType\\ClientCredentials"
                     auth_location:  "body"
 ```
 
@@ -123,7 +121,7 @@ eight_points_guzzle:
 | auth_location | The place where to put client_id and client_secret in auth request. <br/>Default: headers. Allowed values: body, headers. | no | body |
 | resource | The App ID URI of the web API (secured resource) | no | https://service.contoso.com/ |
 | scope | One or more scope values indicating which parts of the user's account you wish to access | no | administration |
-| grant_type | Grant type class path. Class should implement GrantTypeInterface. <br/> Default: `Sainsburys\\Guzzle\\Oauth2\\GrantType\\PasswordCredentials` | no | `Sainsburys\\Guzzle\\Oauth2\\GrantType\\ClientCredentials` |
+| grant_type | Grant type class path. Class should implement GrantTypeInterface. <br/> Default: `Sainsburys\\Guzzle\\Oauth2\\GrantType\\ClientCredentials` | no | `Sainsburys\\Guzzle\\Oauth2\\GrantType\\PasswordCredentials`<br/>`Sainsburys\\Guzzle\\Oauth2\\GrantType\\AuthorizationCode`<br/>`Sainsburys\\Guzzle\\Oauth2\\GrantType\\JwtBearer` |
 
 See more information about middleware [here][3].
 

--- a/src/GuzzleBundleOAuth2Plugin.php
+++ b/src/GuzzleBundleOAuth2Plugin.php
@@ -6,7 +6,9 @@ namespace Gregurco\Bundle\GuzzleBundleOAuth2Plugin;
 use Gregurco\Bundle\GuzzleBundleOAuth2Plugin\DependencyInjection\GuzzleBundleOAuth2Extension;
 use EightPoints\Bundle\GuzzleBundle\EightPointsGuzzleBundlePlugin;
 use Sainsburys\Guzzle\Oauth2\GrantType\ClientCredentials;
+use Sainsburys\Guzzle\Oauth2\GrantType\GrantTypeBase;
 use Sainsburys\Guzzle\Oauth2\GrantType\GrantTypeInterface;
+use Sainsburys\Guzzle\Oauth2\GrantType\JwtBearer;
 use Sainsburys\Guzzle\Oauth2\GrantType\PasswordCredentials;
 use Sainsburys\Guzzle\Oauth2\GrantType\RefreshToken;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
@@ -41,13 +43,26 @@ class GuzzleBundleOAuth2Plugin extends Bundle implements EightPointsGuzzleBundle
             $middlewareConfig = [
                 PasswordCredentials::CONFIG_USERNAME => $config['username'],
                 PasswordCredentials::CONFIG_PASSWORD => $config['password'],
-                PasswordCredentials::CONFIG_CLIENT_ID => $config['client_id'],
-                PasswordCredentials::CONFIG_CLIENT_SECRET => $config['client_secret'],
-                PasswordCredentials::CONFIG_TOKEN_URL => $config['token_url'],
-                PasswordCredentials::CONFIG_AUTH_LOCATION => $config['auth_location'],
-                PasswordCredentials::CONFIG_RESOURCE => $config['resource'],
+                GrantTypeBase::CONFIG_CLIENT_ID => $config['client_id'],
+                GrantTypeBase::CONFIG_CLIENT_SECRET => $config['client_secret'],
+                GrantTypeBase::CONFIG_TOKEN_URL => $config['token_url'],
+                GrantTypeBase::CONFIG_AUTH_LOCATION => $config['auth_location'],
+                GrantTypeBase::CONFIG_RESOURCE => $config['resource'],
+                JwtBearer::CONFIG_PRIVATE_KEY => null,
                 'scope' => $config['scope'],
             ];
+
+            if ($config['private_key']) {
+                // Define Client
+                $privateKeyDefinitionName = sprintf('guzzle_bundle_oauth2_plugin.private_key.%s', $clientName);
+                $privateKeyDefinition = new Definition(\SplFileObject::class);
+                $privateKeyDefinition->addArgument($config['private_key']);
+                $container->setDefinition($privateKeyDefinitionName, $privateKeyDefinition);
+
+                $middlewareConfig += [
+                    JwtBearer::CONFIG_PRIVATE_KEY => new Reference($privateKeyDefinitionName),
+                ];
+            }
 
             // Define Client
             $oauthClientDefinitionName = sprintf('guzzle_bundle_oauth2_plugin.client.%s', $clientName);
@@ -114,6 +129,14 @@ class GuzzleBundleOAuth2Plugin extends Bundle implements EightPointsGuzzleBundle
                 })
                 ->thenInvalid('username and password are required')
             ->end()
+            ->validate()
+                ->ifTrue(function (array $config) {
+                    return $config['enabled'] === true &&
+                        $config['grant_type'] === JwtBearer::class &&
+                        empty($config['private_key']);
+                })
+                ->thenInvalid('private_key is required')
+            ->end()
             ->children()
                 ->scalarNode('base_uri')->defaultNull()->end()
                 ->scalarNode('username')->defaultNull()->end()
@@ -123,6 +146,7 @@ class GuzzleBundleOAuth2Plugin extends Bundle implements EightPointsGuzzleBundle
                 ->scalarNode('token_url')->defaultNull()->end()
                 ->scalarNode('scope')->defaultNull()->end()
                 ->scalarNode('resource')->defaultNull()->end()
+                ->scalarNode('private_key')->defaultNull()->end()
                 ->scalarNode('auth_location')
                     ->defaultValue('headers')
                     ->validate()

--- a/src/GuzzleBundleOAuth2Plugin.php
+++ b/src/GuzzleBundleOAuth2Plugin.php
@@ -59,9 +59,7 @@ class GuzzleBundleOAuth2Plugin extends Bundle implements EightPointsGuzzleBundle
                 $privateKeyDefinition->addArgument($config['private_key']);
                 $container->setDefinition($privateKeyDefinitionName, $privateKeyDefinition);
 
-                $middlewareConfig += [
-                    JwtBearer::CONFIG_PRIVATE_KEY => new Reference($privateKeyDefinitionName),
-                ];
+                $middlewareConfig[JwtBearer::CONFIG_PRIVATE_KEY] = new Reference($privateKeyDefinitionName);
             }
 
             // Define Client

--- a/tests/GuzzleBundleOAuth2PluginTest.php
+++ b/tests/GuzzleBundleOAuth2PluginTest.php
@@ -6,6 +6,7 @@ use EightPoints\Bundle\GuzzleBundle\DependencyInjection\Configuration;
 use EightPoints\Bundle\GuzzleBundle\EightPointsGuzzleBundlePlugin;
 use Gregurco\Bundle\GuzzleBundleOAuth2Plugin\GuzzleBundleOAuth2Plugin;
 use Sainsburys\Guzzle\Oauth2\GrantType\ClientCredentials;
+use Sainsburys\Guzzle\Oauth2\GrantType\GrantTypeInterface;
 use Sainsburys\Guzzle\Oauth2\GrantType\PasswordCredentials;
 use Sainsburys\Guzzle\Oauth2\GrantType\RefreshToken;
 use Sainsburys\Guzzle\Oauth2\Middleware\OAuthMiddleware;
@@ -57,7 +58,7 @@ class GuzzleBundleOAuth2PluginTest extends TestCase
                 'scope' => null,
                 'resource' => null,
                 'auth_location' => 'headers',
-                'grant_type' => PasswordCredentials::class,
+                'grant_type' => ClientCredentials::class,
             ],
             $node->getDefaultValue()
         );
@@ -91,14 +92,14 @@ class GuzzleBundleOAuth2PluginTest extends TestCase
                 'enabled' => true,
                 'base_uri' => 'https://example.com',
                 'token_url' => '/oauth/token',
-                'username' => 'test@example.com',
-                'password' => 'pa55w0rd',
+                'username' => null,
+                'password' => null,
                 'client_id' => 'test-client-id',
                 'client_secret' => '',
                 'scope' => 'administration',
                 'resource' => null,
                 'auth_location' => 'headers',
-                'grant_type' => PasswordCredentials::class,
+                'grant_type' => ClientCredentials::class,
             ],
             $container, 'api_payment', $handler
         );
@@ -141,29 +142,44 @@ class GuzzleBundleOAuth2PluginTest extends TestCase
     public function provideValidConfigurationData() : array
     {
         return [
-            'config is empty' => [[]],
             'plugin is disabled' => [[
                 'enabled' => false,
             ]],
             'plugin is enabled' => [[
                 'enabled' => true,
+                'base_uri' => 'https://example.com',
+                'client_id' => 's6BhdRkqt3',
             ]],
             'PasswordCredentials in grant_type' => [[
+                'base_uri' => 'https://example.com',
+                'client_id' => 's6BhdRkqt3',
+                'username' => 'johndoe',
+                'password' => 'A3ddj3w',
                 'grant_type' => PasswordCredentials::class,
             ]],
             'ClientCredentials in grant_type' => [[
+                'base_uri' => 'https://example.com',
+                'client_id' => 's6BhdRkqt3',
                 'grant_type' => ClientCredentials::class,
             ]],
             'JwtBearer in grant_type' => [[
+                'base_uri' => 'https://example.com',
+                'client_id' => 's6BhdRkqt3',
                 'grant_type' => ClientCredentials::class,
             ]],
             'RefreshToken in grant_type' => [[
+                'base_uri' => 'https://example.com',
+                'client_id' => 's6BhdRkqt3',
                 'grant_type' => RefreshToken::class,
             ]],
             'headers in auth_location' => [[
+                'base_uri' => 'https://example.com',
+                'client_id' => 's6BhdRkqt3',
                 'auth_location' => 'headers',
             ]],
             'body in auth_location' => [[
+                'base_uri' => 'https://example.com',
+                'client_id' => 's6BhdRkqt3',
                 'auth_location' => 'body',
             ]],
         ];
@@ -173,10 +189,12 @@ class GuzzleBundleOAuth2PluginTest extends TestCase
      * @dataProvider provideInvalidConfigurationData
      *
      * @param array $pluginConfiguration
+     * @param string $message
      */
-    public function testAddConfigurationWithInvalidData(array $pluginConfiguration)
+    public function testAddConfigurationWithInvalidData(array $pluginConfiguration, string $message)
     {
         $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage($message);
 
         $config = [
             'eight_points_guzzle' => [
@@ -200,15 +218,62 @@ class GuzzleBundleOAuth2PluginTest extends TestCase
     public function provideInvalidConfigurationData() : array
     {
         return [
-            'invalid type in grant_type' => [[
-                'grant_type' => true,
-            ]],
-            'invalid class in grant_type' => [[
-                'grant_type' => \stdClass::class,
-            ]],
-            'invalid grant_type' => [[
-                'auth_location' => 'somewhere',
-            ]],
+            'without base_uri' => [
+                'config' => [
+                    'enabled' => true,
+                    'client_id' => 's6BhdRkqt3',
+                ],
+                'exception message' => 'base_uri is required',
+            ],
+            'without client_id' => [
+                'config' => [
+                    'enabled' => true,
+                    'base_uri' => 'https://example.com',
+                ],
+                'exception message' => 'client_id is required',
+            ],
+            'invalid type in grant_type' => [
+                'config' => [
+                    'base_uri' => 'https://example.com',
+                    'client_id' => 's6BhdRkqt3',
+                    'grant_type' => true,
+                ],
+                'exception message' => sprintf('Use instance of %s in grant_type', GrantTypeInterface::class),
+            ],
+            'invalid class in grant_type' => [
+                'config' => [
+                    'base_uri' => 'https://example.com',
+                    'client_id' => 's6BhdRkqt3',
+                    'grant_type' => \stdClass::class,
+                ],
+                'exception message' => sprintf('Use instance of %s in grant_type', GrantTypeInterface::class),
+            ],
+            'invalid auth_location' => [
+                'config' => [
+                    'base_uri' => 'https://example.com',
+                    'client_id' => 's6BhdRkqt3',
+                    'auth_location' => 'somewhere',
+                ],
+                'exception message' => 'Invalid auth_location "somewhere". Allowed values: headers, body.',
+            ],
+            'PasswordCredentials grant type without username' => [
+                'config' => [
+                    'base_uri' => 'https://example.com',
+                    'client_id' => 's6BhdRkqt3',
+                    'password' => 'A3ddj3w',
+                    'grant_type' => PasswordCredentials::class,
+                ],
+                'exception message' => 'username and password are required',
+            ],
+            'PasswordCredentials grant type without password' => [
+                'config' => [
+                    'base_uri' => 'https://example.com',
+                    'client_id' => 's6BhdRkqt3',
+                    'username' => 'johndoe',
+                    'grant_type' => PasswordCredentials::class,
+                ],
+                'exception message' => 'username and password are required',
+            ],
         ];
     }
 }

--- a/tests/GuzzleBundleOAuth2PluginTest.php
+++ b/tests/GuzzleBundleOAuth2PluginTest.php
@@ -114,6 +114,41 @@ class GuzzleBundleOAuth2PluginTest extends TestCase
         $this->assertCount(3, $clientMiddlewareDefinition->getArguments());
     }
 
+    public function testLoadForClientWithPrivateKey()
+    {
+        $handler = new Definition();
+        $container = new ContainerBuilder();
+
+        $this->plugin->loadForClient(
+            [
+                'enabled' => true,
+                'base_uri' => 'https://example.com',
+                'token_url' => '/oauth/token',
+                'username' => null,
+                'password' => null,
+                'client_id' => 'test-client-id',
+                'client_secret' => '',
+                'scope' => 'administration',
+                'resource' => null,
+                'private_key' => '/path/to/private.key',
+                'auth_location' => 'headers',
+                'grant_type' => JwtBearer::class,
+            ],
+            $container, 'api_payment', $handler
+        );
+
+        $this->assertTrue($container->hasDefinition('guzzle_bundle_oauth2_plugin.middleware.api_payment'));
+        $this->assertCount(2, $handler->getMethodCalls());
+
+        $clientMiddlewareDefinition = $container->getDefinition('guzzle_bundle_oauth2_plugin.middleware.api_payment');
+        $this->assertCount(3, $clientMiddlewareDefinition->getArguments());
+
+        $this->assertTrue($container->hasDefinition('guzzle_bundle_oauth2_plugin.private_key.api_payment'));
+        $clientMiddlewareDefinition = $container->getDefinition('guzzle_bundle_oauth2_plugin.private_key.api_payment');
+        $this->assertCount(1, $clientMiddlewareDefinition->getArguments());
+        $this->assertEquals('/path/to/private.key', $clientMiddlewareDefinition->getArgument(0));
+    }
+
     /**
      * @dataProvider provideValidConfigurationData
      *

--- a/tests/GuzzleBundleOAuth2PluginTest.php
+++ b/tests/GuzzleBundleOAuth2PluginTest.php
@@ -7,6 +7,7 @@ use EightPoints\Bundle\GuzzleBundle\EightPointsGuzzleBundlePlugin;
 use Gregurco\Bundle\GuzzleBundleOAuth2Plugin\GuzzleBundleOAuth2Plugin;
 use Sainsburys\Guzzle\Oauth2\GrantType\ClientCredentials;
 use Sainsburys\Guzzle\Oauth2\GrantType\GrantTypeInterface;
+use Sainsburys\Guzzle\Oauth2\GrantType\JwtBearer;
 use Sainsburys\Guzzle\Oauth2\GrantType\PasswordCredentials;
 use Sainsburys\Guzzle\Oauth2\GrantType\RefreshToken;
 use Sainsburys\Guzzle\Oauth2\Middleware\OAuthMiddleware;
@@ -57,6 +58,7 @@ class GuzzleBundleOAuth2PluginTest extends TestCase
                 'token_url' => null,
                 'scope' => null,
                 'resource' => null,
+                'private_key' => null,
                 'auth_location' => 'headers',
                 'grant_type' => ClientCredentials::class,
             ],
@@ -98,6 +100,7 @@ class GuzzleBundleOAuth2PluginTest extends TestCase
                 'client_secret' => '',
                 'scope' => 'administration',
                 'resource' => null,
+                'private_key' => null,
                 'auth_location' => 'headers',
                 'grant_type' => ClientCredentials::class,
             ],
@@ -162,15 +165,16 @@ class GuzzleBundleOAuth2PluginTest extends TestCase
                 'client_id' => 's6BhdRkqt3',
                 'grant_type' => ClientCredentials::class,
             ]],
-            'JwtBearer in grant_type' => [[
-                'base_uri' => 'https://example.com',
-                'client_id' => 's6BhdRkqt3',
-                'grant_type' => ClientCredentials::class,
-            ]],
             'RefreshToken in grant_type' => [[
                 'base_uri' => 'https://example.com',
                 'client_id' => 's6BhdRkqt3',
                 'grant_type' => RefreshToken::class,
+            ]],
+            'JwtBearer in grant_type' => [[
+                'base_uri' => 'https://example.com',
+                'client_id' => 's6BhdRkqt3',
+                'private_key' => '/path/to/private/key',
+                'grant_type' => JwtBearer::class,
             ]],
             'headers in auth_location' => [[
                 'base_uri' => 'https://example.com',
@@ -273,6 +277,14 @@ class GuzzleBundleOAuth2PluginTest extends TestCase
                     'grant_type' => PasswordCredentials::class,
                 ],
                 'exception message' => 'username and password are required',
+            ],
+            'JwtBearer grant type without private_key' => [
+                'config' => [
+                    'base_uri' => 'https://example.com',
+                    'client_id' => 's6BhdRkqt3',
+                    'grant_type' => JwtBearer::class,
+                ],
+                'exception message' => 'private_key is required',
             ],
         ];
     }


### PR DESCRIPTION
- Improve config validation
- Write tests for configuration
- Do ClientCredentials as default grant type
- support private_key option (required by JwtBearer grant type)