### PR TITLE
Feature/add cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,10 @@ eight_points_guzzle:
 | resource | The App ID URI of the web API (secured resource) | no | https://service.contoso.com/ |
 | private_key | Path to private key | for JwtBearer grant type | `"%kernel.root_dir%/path/to/private.key"` |
 | scope | One or more scope values indicating which parts of the user's account you wish to access | no | administration |
+| audience | | no | |
 | grant_type | Grant type class path. Class should implement GrantTypeInterface. <br/> Default: `Sainsburys\\Guzzle\\Oauth2\\GrantType\\ClientCredentials` | no | `Sainsburys\\Guzzle\\Oauth2\\GrantType\\PasswordCredentials`<br/>`Sainsburys\\Guzzle\\Oauth2\\GrantType\\AuthorizationCode`<br/>`Sainsburys\\Guzzle\\Oauth2\\GrantType\\JwtBearer` |
-| persistent | Token will be stored in session. <br/> Default: false | no | |
+| persistent | Token will be stored in session unless grant_type is client credentials; in which case it will be stored in the app cache. <br/> Default: false | no | |
+| retry_limit | How many times request will be repeated on failure. <br/> Default: 5 | no | |
 
 See more information about middleware [here][3].
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
     "keywords":    ["oauth2", "middleware", "plugin", "framework", "http", "rest", "web service", "curl", "client", "HTTP client"],
     "homepage":    "https://github.com/gregurco/GuzzleBundleOAuth2Plugin",
     "license":     "MIT",
-
     "authors": [
         {
             "name":     "Gregurco Vlad",

--- a/src/Middleware/CachedOAuthMiddleware.php
+++ b/src/Middleware/CachedOAuthMiddleware.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Gregurco\Bundle\GuzzleBundleOAuth2Plugin\Middleware;
+
+use GuzzleHttp\ClientInterface;
+use Psr\Cache\InvalidArgumentException;
+use Sainsburys\Guzzle\Oauth2\AccessToken;
+use Sainsburys\Guzzle\Oauth2\GrantType\GrantTypeInterface;
+use Sainsburys\Guzzle\Oauth2\GrantType\RefreshTokenGrantTypeInterface;
+use Sainsburys\Guzzle\Oauth2\Middleware\OAuthMiddleware;
+use Symfony\Component\Cache\Adapter\AdapterInterface;
+
+class CachedOAuthMiddleware extends OAuthMiddleware
+{
+    /**
+     * @var AdapterInterface cacheClient
+     */
+    private $cacheClient;
+
+    /**
+     * @var string clientName
+     */
+    private $clientName;
+
+    /**
+     * Create a new Oauth2 subscriber.
+     *
+     * @param ClientInterface $client
+     * @param GrantTypeInterface|null $grantType
+     * @param RefreshTokenGrantTypeInterface|null $refreshTokenGrantType
+     * @param AdapterInterface $cacheClient
+     * @param string $clientName
+     */
+    public function __construct(
+        ClientInterface $client,
+        GrantTypeInterface $grantType = null,
+        RefreshTokenGrantTypeInterface $refreshTokenGrantType = null,
+        AdapterInterface $cacheClient,
+        string $clientName
+    ) {
+        parent::__construct($client, $grantType, $refreshTokenGrantType);
+
+        $this->cacheClient = $cacheClient;
+        $this->clientName = $clientName;
+    }
+
+    /**
+     * Get a new access token.
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return AccessToken|null
+     */
+    protected function acquireAccessToken()
+    {
+        $token = parent::acquireAccessToken();
+
+        $this->cacheToken($token);
+
+        return $token;
+    }
+
+    /**
+     * cacheToken sets the token in the cache adapter
+     *
+     * @param AccessToken $token
+     *
+     * @throws InvalidArgumentException
+     */
+    protected function cacheToken(AccessToken $token)
+    {
+        $item = $this->cacheClient->getItem(sprintf('oauth.token.%s', $this->clientName));
+
+        $item->set(
+            [
+                'token' => $token->getToken(),
+                'type' => $token->getType(),
+                'data' => $token->getData(),
+            ]
+        );
+        $item->tag('oauth');
+        $expires = $token->getExpires();
+
+        if ($expires) {
+            $item->expiresAt($expires->sub(\DateInterval::createFromDateString('1 minute')));
+        }
+
+        $this->cacheClient->saveDeferred($item);
+    }
+
+    /**
+     * getAccessToken will get the oauth token from the cache if available
+     *
+     * @throws \Exception
+     * @throws InvalidArgumentException
+     *
+     * @return null|AccessToken
+     */
+    public function getAccessToken()
+    {
+        if ($this->accessToken === null) {
+            $this->restoreTokenFromCache();
+        }
+
+        return parent::getAccessToken();
+    }
+
+    /**
+     * restoreTokenFromCache
+     *
+     * @throws \Exception
+     * @throws InvalidArgumentException
+     */
+    protected function restoreTokenFromCache()
+    {
+        $item = $this->cacheClient->getItem(sprintf('oauth.token.%s', $this->clientName));
+
+        if ($item->isHit()) {
+            $tokenData = $item->get();
+
+            $this->setAccessToken(
+                new AccessToken(
+                    $tokenData['token'],
+                    $tokenData['type'],
+                    $tokenData['data']
+                )
+            );
+        }
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -6,5 +6,6 @@
     <parameters>
 		<parameter key="guzzle_bundle_oauth2_plugin.middleware.class">Sainsburys\Guzzle\Oauth2\Middleware\OAuthMiddleware</parameter>
 		<parameter key="guzzle_bundle_oauth2_plugin.persistent_middleware.class">Gregurco\Bundle\GuzzleBundleOAuth2Plugin\Middleware\PersistentOAuthMiddleware</parameter>
+		<parameter key="guzzle_bundle_oauth2_plugin.cached_middleware.class">Gregurco\Bundle\GuzzleBundleOAuth2Plugin\Middleware\CachedOAuthMiddleware</parameter>
     </parameters>
 </container>

--- a/tests/GuzzleBundleOAuth2PluginTest.php
+++ b/tests/GuzzleBundleOAuth2PluginTest.php
@@ -57,11 +57,13 @@ class GuzzleBundleOAuth2PluginTest extends TestCase
                 'client_secret' => null,
                 'token_url' => null,
                 'scope' => null,
+                'audience' => null,
                 'resource' => null,
                 'private_key' => null,
                 'auth_location' => 'headers',
                 'grant_type' => ClientCredentials::class,
                 'persistent' => false,
+                'retry_limit' => 5,
             ],
             $node->getDefaultValue()
         );
@@ -100,11 +102,13 @@ class GuzzleBundleOAuth2PluginTest extends TestCase
                 'client_id' => 'test-client-id',
                 'client_secret' => '',
                 'scope' => 'administration',
+                'audience' => null,
                 'resource' => null,
                 'private_key' => null,
                 'auth_location' => 'headers',
                 'grant_type' => ClientCredentials::class,
                 'persistent' => false,
+                'retry_limit' => 5,
             ],
             $container, 'api_payment', $handler
         );
@@ -131,11 +135,13 @@ class GuzzleBundleOAuth2PluginTest extends TestCase
                 'client_id' => 'test-client-id',
                 'client_secret' => '',
                 'scope' => 'administration',
+                'audience' => null,
                 'resource' => null,
                 'private_key' => '/path/to/private.key',
                 'auth_location' => 'headers',
                 'grant_type' => JwtBearer::class,
                 'persistent' => false,
+                'retry_limit' => 5,
             ],
             $container, 'api_payment', $handler
         );


### PR DESCRIPTION
Allow the `persistent` option to store the tokens in cache if the grant type is client credentials. This will use the standard PSR-6 interface that Symfony works with and is configured as `cache.app`.

The code in `src/GuzzleBundleOAuth2Plugin.php` which chooses the class to return for the persistence middleware could probably be refactored at some point but does work in our tests against a redis cache storage.