### PR TITLE
Make the token data store cache expiry even when data says expires_in

### DIFF
--- a/src/Middleware/CachedOAuthMiddleware.php
+++ b/src/Middleware/CachedOAuthMiddleware.php
@@ -71,18 +71,19 @@ class CachedOAuthMiddleware extends OAuthMiddleware
     {
         $item = $this->cacheClient->getItem(sprintf('oauth.token.%s', $this->clientName));
 
+        $expires = $token->getExpires();
+
         $item->set(
             [
                 'token' => $token->getToken(),
                 'type' => $token->getType(),
-                'data' => $token->getData(),
+                'data' => array_merge($token->getData(), ['expires' => $expires->getTimestamp()]),
             ]
         );
         $item->tag('oauth');
-        $expires = $token->getExpires();
 
         if ($expires) {
-            $item->expiresAt($expires->sub(\DateInterval::createFromDateString('1 minute')));
+            $item->expiresAt($expires->sub(\DateInterval::createFromDateString('10 seconds')));
         }
 
         $this->cacheClient->saveDeferred($item);

--- a/src/Middleware/PersistentOAuthMiddleware.php
+++ b/src/Middleware/PersistentOAuthMiddleware.php
@@ -58,11 +58,13 @@ class PersistentOAuthMiddleware extends OAuthMiddleware
      */
     protected function storeTokenInSession(AccessToken $token)
     {
+        $expires = $token->getExpires();
+
         $this->session->start();
         $this->session->set($this->clientName . '_token', [
             'token' => $token->getToken(),
             'type' => $token->getType(),
-            'data' => $token->getData(),
+            'data' => array_merge($token->getData(), ['expires' => $expires->getTimestamp()]),
         ]);
         $this->session->save();
     }


### PR DESCRIPTION
We found an issue whereby the token would expire and when `getAccessToken()` was called as a result, the token would be loaded from cache and re-stored as valid because the token data only specifies `expires_in` a certain number of seconds.

The token was never expiring within the code because each time it was loaded from cache, the check for expiry would return as a valid token since the expiry was always `n` seconds from now.

We also reduced the cache expiry timeout because 1 minute is a long time in programming terms.

In Symfony 4.2 there is stampede protection built in but we can't assume anything in a contrib package which may be being used as standalone or on other versions.